### PR TITLE
Updated to support newer Android versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /local.properties
 /.idea
 /build
+app/release

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.1"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId "com.antweb.silentboot"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 30
         versionCode 20
         versionName "2.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.antweb.silentboot"
     android:installLocation="internalOnly">
-
-    <uses-sdk android:maxSdkVersion="27" />
-
+    
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <supports-screens
         android:anyDensity="true"
@@ -33,12 +34,22 @@
             android:name=".HelpActivity"
             android:label="@string/activity_label_help" />
 
+        <service
+            android:name=".ShutdownReceiverService"
+            android:label="@string/service_label_shutdown" />
+
         <receiver
             android:name=".BootReceiver"
             android:enabled="true"
             android:exported="true">
             <intent-filter android:priority="9999">
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+            <intent-filter android:priority="9999">
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+            <intent-filter android:priority="9999">
+                <action android:name="android.intent.action.MY_PACKAGE_UNSUSPENDED" />
             </intent-filter>
         </receiver>
         <receiver

--- a/app/src/main/java/com/antweb/silentboot/HelpActivity.java
+++ b/app/src/main/java/com/antweb/silentboot/HelpActivity.java
@@ -4,7 +4,6 @@ import android.annotation.TargetApi;
 import android.app.ActionBar;
 import android.app.Activity;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
 
@@ -15,9 +14,7 @@ public class HelpActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.help_activity);
 
-        if (Build.VERSION.SDK_INT > 11) {
-            enableUp();
-        }
+        enableUp();
     }
 
     @TargetApi(11)

--- a/app/src/main/java/com/antweb/silentboot/ShutdownReceiver.java
+++ b/app/src/main/java/com/antweb/silentboot/ShutdownReceiver.java
@@ -1,10 +1,12 @@
 package com.antweb.silentboot;
 
+import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 
@@ -18,11 +20,14 @@ public class ShutdownReceiver extends BroadcastReceiver {
     /**
      * onReceive method
      *
-     * @param context
-     * @intent intent
+     * @param context: application context
+     * @param intent: sources Intent object
      */
     @Override
     public void onReceive(Context context, Intent intent) {
+        if(!Intent.ACTION_SHUTDOWN.equals(intent.getAction()))
+            return;
+
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
 
         if (settings.getBoolean("enabled", true)) {
@@ -59,7 +64,14 @@ public class ShutdownReceiver extends BroadcastReceiver {
                 }
             }
 
-            editor.commit();
+            // Android O+ compatibility
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                editor.putInt("last_dnd", notificationManager.getCurrentInterruptionFilter());
+                notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE);
+            }
+
+            editor.apply();
         }
     }
 }

--- a/app/src/main/java/com/antweb/silentboot/ShutdownReceiverService.java
+++ b/app/src/main/java/com/antweb/silentboot/ShutdownReceiverService.java
@@ -1,0 +1,81 @@
+package com.antweb.silentboot;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.IBinder;
+
+public class ShutdownReceiverService extends Service {
+    static final String DEFAULT_NOTIFICATION_CHANNEL_ID = "PHONE_SHUTDOWN_RECEIVER_SERVICE";
+    static final int ONGOING_NOTIFICATION_ID = 1;
+
+    BroadcastReceiver shutdownReceiver;
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createNotificationChannel();
+            Intent notificationIntent = new Intent(this, MainActivity.class);
+            PendingIntent pendingIntent =
+                    PendingIntent.getActivity(this, 0, notificationIntent, 0);
+            Notification notification =
+                    new Notification.Builder(this, DEFAULT_NOTIFICATION_CHANNEL_ID)
+                            .setSmallIcon(R.drawable.status_gingerbread)
+                            .setBadgeIconType(Notification.BADGE_ICON_NONE)
+                            .setContentIntent(pendingIntent)
+                            .setVisibility(Notification.VISIBILITY_SECRET)
+                            .build();
+
+            startForeground(ONGOING_NOTIFICATION_ID, notification);
+
+            shutdownReceiver = new ShutdownReceiver();
+            registerReceiver(shutdownReceiver, new IntentFilter(Intent.ACTION_SHUTDOWN));
+        }
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = getSystemService(NotificationManager.class);
+            if(nm.getNotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID) != null)
+                return;
+            CharSequence name = getString(R.string.shutdown_notification_channel_name);
+            String description = getString(R.string.shutdown_notification_channel_description);
+            int importance = NotificationManager.IMPORTANCE_NONE;
+            NotificationChannel channel = new NotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID, name, importance);
+            channel.setDescription(description);
+            channel.enableLights(false);
+            channel.enableVibration(false);
+            channel.setShowBadge(false);
+            channel.setBypassDnd(false);
+            channel.setLockscreenVisibility(Notification.VISIBILITY_SECRET);
+            channel.setSound(null, null);
+            nm.createNotificationChannel(channel);
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        if(shutdownReceiver != null)
+            unregisterReceiver(shutdownReceiver);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = getSystemService(NotificationManager.class);
+            nm.cancel(ONGOING_NOTIFICATION_ID);
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,5 +36,9 @@
     <string name="help_text_compat">Compatibility mode improves reliability on phones with low memory. It creates a notification that makes it less likely that the app is killed by the system when it\'s running out of memory.\n</string>
     <string name="help_title_airplanetoggle">Airplane mode toggle</string>
     <string name="help_text_airplanetoggle">Shutting down the phone with airplane mode enabled might prevent Silent Boot from working properly. This option disables airplane mode before shutdown and restores it after startup is complete. THIS WILL BOOT UP YOUR PHONE WITHOUT AIRPLANE MODE! Only enable if you are experiencing issues with Silent Boot and airplane mode!\n</string>
+    <string name="shutdown_service_notification_title">Phone Shutdown Receiver Service</string>
+    <string name="shutdown_notification_channel_name">Phone Shutdown Receiver Service</string>
+    <string name="shutdown_notification_channel_description">Android requires a notification to run the service that is required to capture the shutdown event</string>
+    <string name="service_label_shutdown">Shutdown Service</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha05'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8-all.zip


### PR DESCRIPTION
Updated to support newer Android versions that don't support static ACTION_SHUTDOWN intent by adding dynamic registering and associated service and notification. Should address issue #2. Also targets the latest API and removes the upper limit to Android version. New strings are missing German translations (notification channel text). I've only tested on a Samsung Note10+.

It needs a version change (I didn't update the version in build.gradle).